### PR TITLE
Variables missing from email template sent from worklow

### DIFF
--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -67,6 +67,10 @@ class templateParser
                 } //Fix for Windows Server as it needed to be converted to a string.
                 else if ($field_def['type'] == 'int') {
                     $repl_arr[$key . "_" . $fieldName] = strval($focus->$fieldName);
+                } 
+                // FibreCRM Fix Decimal type issue KC-15 - it needed to be converted to a string.
+				else if ($field_def['type'] == 'decimal') {
+                    $repl_arr[$key . "_" . $fieldName] = strval($focus->$fieldName);
                 } else if ($field_def['type'] == 'image') {
                     $secureLink = $sugar_config['site_url'] . '/' . "public/". $focus->id .  '_' . $fieldName;
                     $file_location = $sugar_config['upload_dir'] . '/'  . $focus->id .  '_' . $fieldName;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
When sending an email from a workflow, the template contains variables that are decimals. When the email is received these variables are not populated.

When the email template replace variable functionality, there is no option to replace a decimal field type. There is currency, dropdown, multi dropdown, int, image available but decimal type does not. I have added decimal field type. 

We have fixed that.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Have the ability to send emails with decimal variables.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Add a decimal filed type variable to an email template, send a test email which will populate the variable. When you receive the email the variable will not be populated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X ] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [X ] My change requires a change to the documentation.
- [X ] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->