### PR TITLE
Enable the export of Account from Target Lists

### DIFF
--- a/include/export_utils.php
+++ b/include/export_utils.php
@@ -355,6 +355,14 @@ function export($type, $records = null, $members = false, $sample=false) {
 
         $customRelateFields = array();
         $selects = array();
+        
+        ## HACK DEV-407 Target list Export is not working
+        if($members == true)
+        {
+        } ## END IF $members != true 
+        ## HACK DEV-407 Target list Export is not working
+        else{
+        
         foreach($records as $record) {
             foreach($record as $recordKey => $recordValue) {
                 if(preg_match('/{relate\s+from=""([^"]+)""\s+to=""([^"]+)""}/', $recordValue, $matches)) {
@@ -432,6 +440,8 @@ function export($type, $records = null, $members = false, $sample=false) {
             }
             $i++;
         }
+        
+        } ## END ELSE IF $members != true
 
 
         foreach($records as $record)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In the current release of 7.8.x you are not able to export target lists containing Accounts, we have fixed this.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Have the ability to export target lists containing Accounts to .csv

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Attempt to export from a target list which contains Accounts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://suitecrm.com/wiki/index.php/Coding_Standards).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://suitecrm.com/wiki/index.php/Contributing_to_SuiteCRM) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->